### PR TITLE
Fix performance issues

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -56,7 +56,7 @@
   }
 
   function main() {
-    InterfaceRepainter.call();
+    requestAnimationFrame(InterfaceRepainter.call);
 
     if (AppStore.spaces().length === 0) {
       return;
@@ -75,10 +75,10 @@
     SalesGenerator.call(LeadGenerator.call());
 
     var newMonth = date.getMonth();
-    
+
     if (newMonth !== currentMonth) {
       currentMonth = newMonth;
-    
+
       handleMonthChange();
     }
 


### PR DESCRIPTION
Call InterfaceRepainter with RequestAnimationFrame so it is only called
when the browser is ready to repaint.

Seems to stop the game from freezing. There might be more performance
wins by moving some of the logic to a worker if necessary.